### PR TITLE
Bug fix for new item creation when type selected.

### DIFF
--- a/components/addAnItemButton.jsx
+++ b/components/addAnItemButton.jsx
@@ -15,10 +15,10 @@ export default function AddAnItemButton({addAnItem, pageOnly=false}) {
     const handleShow = () => setShow(true);
 
     const optionSelected = (e) => {
-        debugLog(debugOn, e.target.id)
+        debugLog(debugOn, e)
         
         setShow(false);
-        addAnItem(e.target.id, 'addAnItemOnTop');
+        addAnItem(e, 'addAnItemOnTop');
     }
 
     return (

--- a/components/itemTypeModal.jsx
+++ b/components/itemTypeModal.jsx
@@ -14,14 +14,14 @@ export default function ItemTypeModal({show=false, optionSelected, handleClose, 
         </Modal.Header>
         <Modal.Body>
             <ListGroup>
-                <ListGroup.Item id='Page' action onClick={optionSelected} className="pt-3 pb-3"><i className="fa fa-file-text-o me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Page</em></ListGroup.Item>
+                <ListGroup.Item id='Page' action onClick={()=>optionSelected('Page')} className="pt-3 pb-3"><i className="fa fa-file-text-o me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Page</em></ListGroup.Item>
                 { 
                     pageOnly?'':
                     <>
-                        <ListGroup.Item id='Notebook' action onClick={optionSelected} className="pt-3 pb-3"><i className="fa fa-book me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Notebook</em></ListGroup.Item>
-                        <ListGroup.Item id='Diary' action onClick={optionSelected} className="pt-3 pb-3"><i className="fa fa-calendar me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Diary</em></ListGroup.Item>
-                        <ListGroup.Item id='Box' action onClick={optionSelected} className="pt-3 pb-3" variant="primary"><i className="fa fa-archive me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Box</em></ListGroup.Item>
-                        <ListGroup.Item id='Folder' action onClick={optionSelected} className="pt-3 pb-3" variant="warning"><i className="fa fa-folder-o me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Folder</em></ListGroup.Item>
+                        <ListGroup.Item id='Notebook' action onClick={()=>optionSelected('Notebook')} className="pt-3 pb-3"><i className="fa fa-book me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Notebook</em></ListGroup.Item>
+                        <ListGroup.Item id='Diary' action onClick={()=>optionSelected('Diary')} className="pt-3 pb-3"><i className="fa fa-calendar me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Diary</em></ListGroup.Item>
+                        <ListGroup.Item id='Box' action onClick={()=>optionSelected('Box')} className="pt-3 pb-3" variant="primary"><i className="fa fa-archive me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Box</em></ListGroup.Item>
+                        <ListGroup.Item id='Folder' action onClick={()=>optionSelected('Folder')} className="pt-3 pb-3" variant="warning"><i className="fa fa-folder-o me-2 fs-5 fw-light" aria-hidden="true"></i><em className="fs-5 fw-light">Folder</em></ListGroup.Item>
                     </>
                 }
             </ListGroup>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77407676/202915117-5883a286-83bf-4822-a8f5-5d797159c700.png)
When item type is selected in new item modal, if clicked above the text, then empty string was being passed in function. Only working when clicked on the empty space.